### PR TITLE
Remove bash package and add version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:latest
+FROM alpine:3.11.6
 LABEL maintainer="neven.vucinic@nvteh.com"
-RUN apk add --no-cache bash \
-        curl \
-        mtr \
-        iputils \
-        bind-tools \
-        netcat-openbsd \
-        iptraf-ng \
-        tcptraceroute \
-        socat
+RUN apk add --no-cache \
+        bind-tools=9.14.12-r0 \
+        curl=7.67.0-r0 \
+        iptraf-ng=1.1.4-r4 \
+        iputils=20190709-r0 \
+        mtr=0.93-r2 \
+        netcat-openbsd=1.130-r1 \
+        socat=1.7.3.3-r1 \
+        tcptraceroute=1.5b7-r1


### PR DESCRIPTION
This PR enables Docker best practices, security and makes the image tiny. This branch's image size is 22.4 MB.

01. Removed the latest tag from the base image and added 3.11.6. 
02. Removed bash package. Because alpine comes with an inbuilt shell. It saves 1.1 MB.
03. Ordered package names in ascending way. 
04. Added version to each package. 