### PR TITLE
bumping alpine to 3.18.0

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Build
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 LABEL maintainer="neven.vucinic@nvteh.com"
 RUN apk add --no-cache \
-        bind-tools=9.18.13-r0 \
-        curl=8.0.1-r0 \
+        bind-tools=9.18.14-r1 \
+        curl=8.1.2-r0 \
         iptraf-ng=1.2.1-r1 \
-        iputils=20211215-r0 \
-        mtr=0.95-r1 \
-        netcat-openbsd=1.130-r4 \
-        socat=1.7.4.4-r0 \
+        iputils-20221126-r2 \
+        mtr-0.95-r2 \
+        netcat-openbsd-1.219-r1 \
+        socat-1.7.4.4-r1 \
         tcptraceroute=1.5b7-r4


### PR DESCRIPTION
### bumping the alpine version to 3.18.0
Tool version changes:
```
bind-tools-9.18.14-r1
curl-8.1.2-r0
iputils-20221126-r2
mtr-0.95-r2
netcat-openbsd-1.219-r1
socat-1.7.4.4-r1
```